### PR TITLE
Fix link: Attribution to Contributor Covenant.

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -134,5 +134,4 @@ members of the project's leadership.
 
 ### Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at [http://contributor-covenant.org/version/1/4][version]
+This Code of Conduct is adapted from the [Contributor Covenant, version 1.4](http://contributor-covenant.org/version/1/4)


### PR DESCRIPTION
@itisdb I fixed the broken link in the Attribution to Contributor Covenant, could you please review.